### PR TITLE
Fix link to Poke API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Wrapper for [Poke API](https://pokeapi.co), written in Dart. *Supports PokeAPI v
 
 ## Documentation
 
-Full API documentation can be found at [Poke API](https://pokeapi.co/docs/v2.html).
+Full API documentation can be found at [Poke API](https://pokeapi.co/docs/v2).
 
 ## Getting Started
 


### PR DESCRIPTION
The previous link pointed to a non-existing page, which resulted in a 404. The page does not an with the ".html" extension.