### PR TITLE
Fix item attribute naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ import 'package:pokeapi/pokeapi.dart';
   *Must pass an offset and limit as Int (e.g. 1, 1).*
 
   ```dart
-  var response = PokeAPI.getObjectList<ItemAbility>(1, 1);
+  var response = PokeAPI.getObjectList<ItemAttribute>(1, 1);
   ```
 
   #### Get Item Attribute
@@ -559,7 +559,7 @@ import 'package:pokeapi/pokeapi.dart';
   *Must pass an ID as Int (e.g. 1).*
 
   ```dart
-  var response = PokeAPI.getObject<ItemAbility>(1);
+  var response = PokeAPI.getObject<ItemAttribute>(1);
   ```
   
   #### Get Item Attribute by Name
@@ -567,7 +567,7 @@ import 'package:pokeapi/pokeapi.dart';
   *Must pass a name as String (e.g. "countable").*
   
   ```dart
-  var response = PokeAPI.getObjectByName<ItemAbility>("countable");
+  var response = PokeAPI.getObjectByName<ItemAttribute>("countable");
   ```
 </details>
 

--- a/lib/model/item/item-attribute.dart
+++ b/lib/model/item/item-attribute.dart
@@ -1,15 +1,15 @@
 import 'package:pokeapi/model/utils/common.dart';
 
-class ItemAbility {
+class ItemAttribute {
   int? id;
   String? name;
   List<Descriptions>? descriptions;
   List<NamedAPIResource>? items;
   List<Names>? names;
 
-  ItemAbility({this.id, this.name, this.descriptions, this.items, this.names});
+  ItemAttribute({this.id, this.name, this.descriptions, this.items, this.names});
 
-  ItemAbility.fromJson(Map<String, dynamic> json) {
+  ItemAttribute.fromJson(Map<String, dynamic> json) {
     id = json['id'];
     name = json['name'];
     if (json['descriptions'] != null) {
@@ -50,7 +50,7 @@ class ItemAbility {
 
   @override
   String toString() {
-    return 'ItemAbility{id: $id, name: $name, descriptions: $descriptions, items: $items, names: $names}';
+    return 'ItemAttribute{id: $id, name: $name, descriptions: $descriptions, items: $items, names: $names}';
   }
 }
 

--- a/lib/pokeapi.dart
+++ b/lib/pokeapi.dart
@@ -74,7 +74,7 @@ class PokeAPI {
     if (T == Gender) return Gender.fromJson(map as Map<String, dynamic>) as T;
     if (T == GrowthRate) return GrowthRate.fromJson(map as Map<String, dynamic>) as T;
     if (T == Item) return Item.fromJson(map as Map<String, dynamic>) as T;
-    if (T == ItemAbility) return ItemAbility.fromJson(map as Map<String, dynamic>) as T;
+    if (T == ItemAttribute) return ItemAttribute.fromJson(map as Map<String, dynamic>) as T;
     if (T == ItemCategory) return ItemCategory.fromJson(map as Map<String, dynamic>) as T;
     if (T == ItemFlingEffect) return ItemFlingEffect.fromJson(map as Map<String, dynamic>) as T;
     if (T == ItemPocket) return ItemPocket.fromJson(map as Map<String, dynamic>) as T;
@@ -171,7 +171,7 @@ class PokeAPI {
     if (T == Gender) url = api.gender;
     if (T == GrowthRate) url = api.growthRate;
     if (T == Item) url = api.item;
-    if (T == ItemAbility) url = api.itemAttribute;
+    if (T == ItemAttribute) url = api.itemAttribute;
     if (T == ItemCategory) url = api.itemCategory;
     if (T == ItemFlingEffect) url = api.itemFlingEffect;
     if (T == ItemPocket) url = api.itemPocket;

--- a/pokeapi/lib/model/item/item-attribute.dart
+++ b/pokeapi/lib/model/item/item-attribute.dart
@@ -1,15 +1,15 @@
 import 'package:pokeapi/model/utils/common.dart';
 
-class ItemAbility {
+class ItemAttribute {
   int? id;
   String? name;
   List<Descriptions>? descriptions;
   List<NamedAPIResource>? items;
   List<Names>? names;
 
-  ItemAbility({this.id, this.name, this.descriptions, this.items, this.names});
+  ItemAttribute({this.id, this.name, this.descriptions, this.items, this.names});
 
-  ItemAbility.fromJson(Map<String, dynamic> json) {
+  ItemAttribute.fromJson(Map<String, dynamic> json) {
     id = json['id'];
     name = json['name'];
     if (json['descriptions'] != null) {
@@ -50,7 +50,7 @@ class ItemAbility {
 
   @override
   String toString() {
-    return 'ItemAbility{id: $id, name: $name, descriptions: $descriptions, items: $items, names: $names}';
+    return 'ItemAttribute{id: $id, name: $name, descriptions: $descriptions, items: $items, names: $names}';
   }
 }
 

--- a/pokeapi/lib/pokeapi.dart
+++ b/pokeapi/lib/pokeapi.dart
@@ -183,7 +183,7 @@ class PokeAPI {
     if (T == Gender) return Gender.fromJson(map as Map<String, dynamic>) as T;
     if (T == GrowthRate) return GrowthRate.fromJson(map as Map<String, dynamic>) as T;
     if (T == Item) return Item.fromJson(map as Map<String, dynamic>) as T;
-    if (T == ItemAbility) return ItemAbility.fromJson(map as Map<String, dynamic>) as T;
+    if (T == ItemAttribute) return ItemAttribute.fromJson(map as Map<String, dynamic>) as T;
     if (T == ItemCategory) return ItemCategory.fromJson(map as Map<String, dynamic>) as T;
     if (T == ItemFlingEffect) return ItemFlingEffect.fromJson(map as Map<String, dynamic>) as T;
     if (T == ItemPocket) return ItemPocket.fromJson(map as Map<String, dynamic>) as T;
@@ -434,7 +434,7 @@ class PokeAPI {
     if (T == Gender) url = api.gender;
     if (T == GrowthRate) url = api.growthRate;
     if (T == Item) url = api.item;
-    if (T == ItemAbility) url = api.itemAttribute;
+    if (T == ItemAttribute) url = api.itemAttribute;
     if (T == ItemCategory) url = api.itemCategory;
     if (T == ItemFlingEffect) url = api.itemFlingEffect;
     if (T == ItemPocket) url = api.itemPocket;
@@ -487,7 +487,7 @@ class PokeAPI {
     if (T == Gender) return Gender.fromJson(data) as T;
     if (T == GrowthRate) return GrowthRate.fromJson(data) as T;
     if (T == Item) return Item.fromJson(data) as T;
-    if (T == ItemAbility) return ItemAbility.fromJson(data) as T;
+    if (T == ItemAttribute) return ItemAttribute.fromJson(data) as T;
     if (T == ItemCategory) return ItemCategory.fromJson(data) as T;
     if (T == ItemFlingEffect) return ItemFlingEffect.fromJson(data) as T;
     if (T == ItemPocket) return ItemPocket.fromJson(data) as T;

--- a/pokeapi/test/api_test.dart
+++ b/pokeapi/test/api_test.dart
@@ -362,7 +362,7 @@ void main() {
 
     test('getItemAttributeList', () {
       try {
-        expect(getObjectList<ItemAbility>(1, 3), completion(equals(true)));
+        expect(getObjectList<ItemAttribute>(1, 3), completion(equals(true)));
       } catch (e) {
         print(e.toString());
       }
@@ -370,7 +370,7 @@ void main() {
 
     test('getItemAttribute', () {
       try {
-        expect(getObject<ItemAbility>(1), completion(equals(true)));
+        expect(getObject<ItemAttribute>(1), completion(equals(true)));
       } catch (e) {
         print(e.toString());
       }

--- a/test/api_test.dart
+++ b/test/api_test.dart
@@ -469,7 +469,7 @@ void main() {
 
     test('getItemAttributeList', () {
       try {
-        expect(getObjectList<ItemAbility>(1, 3), completion(equals(true)));
+        expect(getObjectList<ItemAttribute>(1, 3), completion(equals(true)));
       } catch (e) {
         print(e.toString());
       }
@@ -477,7 +477,7 @@ void main() {
 
     test('getItemAttribute', () {
       try {
-        expect(getObject<ItemAbility>(1), completion(equals(true)));
+        expect(getObject<ItemAttribute>(1), completion(equals(true)));
       } catch (e) {
         print(e.toString());
       }


### PR DESCRIPTION
## Summary
- rename `ItemAbility` class to `ItemAttribute`
- update PokeAPI mapping and tests
- update README examples

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410bde7050832dadc7819fa9db109a